### PR TITLE
ci: restrict PR security gate to main branch only

### DIFF
--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -3,7 +3,7 @@ name: PR Security Gate (Mobile DevSecOps)
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main, develop]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
Restrict the PR security gate workflow to only trigger on PRs targeting the main branch (removes develop branch trigger).